### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
     - linux
 julia:
     - 0.4
+    - 0.5
+    - nightly
 notifications:
     email: false
 addons:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using Base.Test
 
 include("test.jl")
 
-pkg_dir = Pkg.dir("Rsvg")
+pkg_dir = dirname(dirname(@__FILE__))
 
 @printf("\nTest: dimension of known images")
 


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done
