### PR TITLE
Remove dependency on Gtk.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.6
-Gtk 
 Cairo 
 BinDeps 
 Compat 

--- a/src/Rsvg.jl
+++ b/src/Rsvg.jl
@@ -6,8 +6,8 @@ isfile(depsjl) ? include(depsjl) : error("Rsvg not properly ",
     "installed. Please run\nPkg.build(\"Rsvg\")")
 
 using Cairo
-using Gtk
 
+include("gerror.jl")
 include("types.jl")
 include("calls.jl")
 

--- a/src/calls.jl
+++ b/src/calls.jl
@@ -67,3 +67,10 @@ end
 handle_new_from_data(data::AbstractString)
 """
 handle_new_from_data(data::AbstractString) = handle_new_from_data(data::AbstractString,GError(0,0,0))
+
+"""
+handle_free(handle::RsvgHandle)
+"""
+function handle_free(handle::RsvgHandle)
+    ccall((:rsvg_handle_free,librsvg), Void, (RsvgHandle,), handle)
+end

--- a/src/gerror.jl
+++ b/src/gerror.jl
@@ -1,0 +1,5 @@
+struct GError
+    domain::UInt32
+    code::Cint
+    message::Ptr{UInt8}
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,19 +7,19 @@ type RsvgHandle
 	    
     function RsvgHandle(ptr::Ptr{Void})
         self = new(ptr)
-        #finalizer(self, destroy)
+        finalizer(self, destroy)
         self
     end
 end
 
-# function destroy(handle::RsvgHandle)
-#     if handle.ptr == C_NULL
-#         return
-#     end
-#     Gtk.GLib.gc_unref(handle)
-#     handle.ptr = C_NULL
-#     nothing
-# end
+function destroy(handle::RsvgHandle)
+    if handle.ptr == C_NULL
+        return
+    end
+    handle_free(handle)
+    handle.ptr = C_NULL
+    nothing
+end
 
 """
 RsvgDimensionData is a simple struct of 

--- a/src/types.jl
+++ b/src/types.jl
@@ -12,16 +12,14 @@ type RsvgHandle
     end
 end
 
-function destroy(handle::RsvgHandle)
-    if handle.ptr == C_NULL
-        return
-    end
-    Gtk.GLib.gc_unref(handle)
-    handle.ptr = C_NULL
-    nothing
-end
-
-GError = Gtk.GLib.GError
+# function destroy(handle::RsvgHandle)
+#     if handle.ptr == C_NULL
+#         return
+#     end
+#     Gtk.GLib.gc_unref(handle)
+#     handle.ptr = C_NULL
+#     nothing
+# end
 
 """
 RsvgDimensionData is a simple struct of 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Rsvg
 using Cairo
-using Gtk
 
 
 using Base.Test


### PR DESCRIPTION
Fixes #15.

Or at least I think it does, I'm not entirely sure.

I'm not sure what the ``destroy`` function does/did. As far as I could tell it was actually not used, but I might misunderstand the design here.

In addition to the issue with the icon on Macs, I now also discovered that one can't use Rsvg.jl on juliabox because of the Gtk.jl dependency, so I think getting rid of that is even more beneficial than we originally thought.

It would be absolutely awesome if we could fix this quickly and tag a new release. I will give an official julia tutorial on Thu, and one of the packages I want to show off is https://github.com/fredo-dedup/VegaLite.jl, and I just now realized that it doesn't work on juliabox because of that Gtk.jl dependency. I would totally understand if we can't manage such a short turn around on such short notice, but I thought I might still ask :)