### PR TITLE
Update build.jl for 0.7 and 1.0 support

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 Cairo 
 BinDeps 
 Compat 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,18 +5,18 @@ using Compat
 
 rsvg = library_dependency("rsvg", aliases = ["librsvg", "librsvg-2.2", "librsvg-2-2", "librsvg-2", "librsvg-2.so.2"])
 
-@static if is_linux() begin
+@static if Sys.islinux() begin
         provides(AptGet, "librsvg2-2",rsvg)
     end
 end
 
-@static if is_apple() begin
+@static if Sys.isapple() begin
         using Homebrew
         provides(Homebrew.HB, "librsvg", [rsvg], os=:Darwin)
     end
 end
 
-@static if is_windows() begin
+@static if Sys.iswindows() begin
         using WinRPM
         provides(WinRPM.RPM,"librsvg-2-2",rsvg,os = :Windows)
     end


### PR DESCRIPTION
updated `build.jl` and `REQUIRE` to make Rsvg.jl work with 1.0 and 0.7.