### PR TITLE
Remove support for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ arch:
   - x64
   - x86
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - 1.2
@@ -17,9 +16,6 @@ matrix:
   exclude:
     - os: osx
       arch: x86
-    - os: windows
-      arch: x86
-      julia: 0.7
   allow_failures:
   - julia: nightly
 notifications:

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 Cairo = "0.8"
 BinaryProvider = "0.5.5"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: 1.1
   - julia_version: 1.2


### PR DESCRIPTION
CI tests regularly only fail on that platform, and I think it is not worth spending time trying to fix that. I think the time of 0.7 has passed, and we can just drop support for it.